### PR TITLE
Pathlib.glob

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -52,7 +52,6 @@ runs:
       if: ${{ inputs.rust-version != -1 }}
       uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
-        profile: minimal
         toolchain: ${{ inputs.rust-version }}
     - name: Set up Dotnet
       if: ${{ inputs.dotnet-version  != -1 }}

--- a/advent_of_action/main.py
+++ b/advent_of_action/main.py
@@ -130,8 +130,7 @@ def main() -> None:
         make_input_file(day_dir)
 
         for solution_dir in sorted(list(day_dir.glob("*_*"))):
-            filenames = set([x.name for x in solution_dir.iterdir() if x.is_file()])
-            if ".optout" in filenames:
+            if ".optout" in set([x.name for x in solution_dir.iterdir() if x.is_file()]):
                 continue
             directory = solution_dir.parts[1]
             language, person = directory.split("_", maxsplit=1)


### PR DESCRIPTION
Make our expected directory structure more explicit, and cleaner, by using path.glob() in place of path.walk().