### PR TITLE
Add pygount

### DIFF
--- a/.github/workflows/functional_tests.yaml
+++ b/.github/workflows/functional_tests.yaml
@@ -35,6 +35,7 @@ jobs:
           echo "..."
           sed -i -E 's/[0-9]+\.[0-9]+/x/' tests/README.md
           sed -i -E 's/[0-9]+/y/' tests/README.md
+          sed -i -E 's/[0-9]+/a/' tests/README.md
           sed -i -E 's/[0-9]+/z/' tests/README.md
           diff --ignore-all-space --ignore-blank-lines tests/README.md tests/EXPECTED_README.md
   test_with_explicit_inputs:

--- a/.github/workflows/functional_tests.yaml
+++ b/.github/workflows/functional_tests.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Run our action
         uses: ./
         with:
-          python-version: "3.13"
+          python-version: "3.12"
           working-directory: tests/
           gpg-passphrase: ${{ secrets.GPG_PASS }}
       - name: Compare results
@@ -54,7 +54,7 @@ jobs:
           working-directory: tests/
           gpg-passphrase: ${{ secrets.GPG_PASS }}
           timeout-seconds: 30
-          python-version: "3.13"
+          python-version: "3.12"
           racket-version: "-1"
           rust-version: "-1"
           dotnet-version: "-1"

--- a/.github/workflows/functional_tests.yaml
+++ b/.github/workflows/functional_tests.yaml
@@ -71,5 +71,6 @@ jobs:
           echo "..."
           sed -i -E 's/[0-9]+\.[0-9]+/x/' tests/README.md
           sed -i -E 's/[0-9]+/y/' tests/README.md
+          sed -i -E 's/[0-9]+/a/' tests/README.md
           sed -i -E 's/[0-9]+/z/' tests/README.md
           diff --ignore-all-space --ignore-blank-lines tests/README.md tests/EXPECTED_README_4.md

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.13'
+          python-version: '3.12'
       - name: Install poetry
         uses: abatilo/actions-poetry@v3
       - name: Check poetry.lock consistency

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -17,7 +17,7 @@ jobs:
           ref: ${{ github.head_ref || github.ref_name }}
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.13'
+          python-version: '3.12'
       - run: pip install .[coverage]
         shell: bash
       - run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
     hooks:
       - id: pyre
         name: Pyre
-        entry: poetry run pyre --strict --noninteractive check
+        entry: poetry run pyre --optional-search-path=stubs/ --strict --noninteractive check
         language: system
         pass_filenames: false
         types: [python]

--- a/README.md
+++ b/README.md
@@ -3,12 +3,12 @@
 ![Test Coverage](tests/badge.svg)
 
 If you and your friends/colleagues share a repo for [Advent of Code](https://adventofcode.com), you can use this to run and compare your solutions to each day's problems.
-It will time each person's solution and monitor maximum memory usage, saving the results to the README:
+It will time each person's solution, monitor maximum memory usage and count the lines of code, saving the results to the README:
 
-| day | language | who | part | time (s) | mem (KiB) | notes |
-| --- | --- | --- | --- | --- | --- | --- |
-| 01 | python | tina | one | 0.00 | 9728 |  |
-| 01 | python | tina | two | 0.02 | 9856 |  |
+| day | language | who | lines | part | time (s) | mem (KiB) | notes |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| 01 | python | tina | 15 | one | 0.00 | 9728 |  |
+| 01 | python | tina | 15 | two | 0.02 | 9856 |  |
 
 ## Using the Action
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ See [Configuring the Default GitHub Token Permissions](https://docs.github.com/e
           timeout-seconds: 50
 
           # To be passed to the setup-python action.
-          python-version: "3.13"
+          python-version: "3.12"
 
           # To be passed to the setup-dotnet action or -1 to disable.
           dotnet-version: 8

--- a/action.yaml
+++ b/action.yaml
@@ -18,7 +18,7 @@ inputs:
   python-version:
     description: "Python version to use"
     required: false
-    default: "3.13"
+    default: "3.12"
   racket-version:
     description: "Racket version to use. -1 for none."
     required: false

--- a/advent_of_action/main.py
+++ b/advent_of_action/main.py
@@ -7,6 +7,8 @@ from pathlib import Path
 from subprocess import CalledProcessError, TimeoutExpired, run
 from typing import Final
 
+import pygount
+
 from advent_of_action import runners
 from advent_of_action.runners import Commands, Part, execute_command
 
@@ -218,6 +220,17 @@ def get_answers(dirpath: Path) -> tuple[str, str]:
     answers = lines[0], lines[1]
     Path("answers.txt").unlink()
     return answers
+
+
+def count_lines(language: str) -> int:
+    """Count the lines of code in the solution."""
+    extensions: Final = {"python": "py"}
+
+    summary = pygount.ProjectSummary()
+    for filepath in Path(".").rglob(f"*.{extensions[language]}"):
+        summary.add(pygount.SourceAnalysis.from_file(filepath, "pygount"))
+
+    return summary.total_code_count
 
 
 if __name__ == "__main__":

--- a/poetry.lock
+++ b/poetry.lock
@@ -49,6 +49,18 @@ files = [
 ]
 
 [[package]]
+name = "chardet"
+version = "5.2.0"
+description = "Universal encoding detector for Python 3"
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+files = [
+    {file = "chardet-5.2.0-py3-none-any.whl", hash = "sha256:e1cf59446890a00105fe7b7912492ea04b6e6f06d4b742b2c788469e34c82970"},
+    {file = "chardet-5.2.0.tar.gz", hash = "sha256:1b3b6ff479a8c414bc3fa2c0852995695c4a026dcd6d0633b2dd092ca39c1cf7"},
+]
+
+[[package]]
 name = "charset-normalizer"
 version = "3.4.1"
 description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
@@ -317,6 +329,40 @@ files = [
 devel = ["colorama", "json-spec", "jsonschema", "pylint", "pytest", "pytest-benchmark", "pytest-cache", "validictory"]
 
 [[package]]
+name = "gitdb"
+version = "4.0.12"
+description = "Git Object Database"
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+files = [
+    {file = "gitdb-4.0.12-py3-none-any.whl", hash = "sha256:67073e15955400952c6565cc3e707c554a4eea2e428946f7a4c162fab9bd9bcf"},
+    {file = "gitdb-4.0.12.tar.gz", hash = "sha256:5ef71f855d191a3326fcfbc0d5da835f26b13fbcba60c32c21091c349ffdb571"},
+]
+
+[package.dependencies]
+smmap = ">=3.0.1,<6"
+
+[[package]]
+name = "gitpython"
+version = "3.1.44"
+description = "GitPython is a Python library used to interact with Git repositories"
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+files = [
+    {file = "GitPython-3.1.44-py3-none-any.whl", hash = "sha256:9e0e10cda9bed1ee64bc9a6de50e7e38a9c9943241cd7f585f6df3ed28011110"},
+    {file = "gitpython-3.1.44.tar.gz", hash = "sha256:c87e30b26253bf5418b01b0660f818967f3c503193838337fe5e573331249269"},
+]
+
+[package.dependencies]
+gitdb = ">=4.0.1,<5"
+
+[package.extras]
+doc = ["sphinx (>=7.1.2,<7.2)", "sphinx-autodoc-typehints", "sphinx_rtd_theme"]
+test = ["coverage[toml]", "ddt (>=1.1.1,!=1.4.3)", "mock", "mypy", "pre-commit", "pytest (>=7.3.1)", "pytest-cov", "pytest-instafail", "pytest-mock", "pytest-sugar", "typing-extensions"]
+
+[[package]]
 name = "idna"
 version = "3.10"
 description = "Internationalized Domain Names in Applications (IDNA)"
@@ -517,6 +563,31 @@ pyyaml = ">=5.2"
 dev = ["Sphinx (>=5.1.1)", "black (==24.8.0)", "build (>=0.10.0)", "coverage[toml] (>=4.5.4)", "fixit (==2.1.0)", "flake8 (==7.1.1)", "hypothesis (>=4.36.0)", "hypothesmith (>=0.0.4)", "jinja2 (==3.1.5)", "jupyter (>=1.0.0)", "maturin (>=1.7.0,<1.8)", "nbsphinx (>=0.4.2)", "prompt-toolkit (>=2.0.9)", "pyre-check (==0.9.18)", "setuptools-rust (>=1.5.2)", "setuptools_scm (>=6.0.1)", "slotscheck (>=0.7.1)", "sphinx-rtd-theme (>=0.4.3)", "ufmt (==2.8.0)", "usort (==1.0.8.post1)"]
 
 [[package]]
+name = "markdown-it-py"
+version = "3.0.0"
+description = "Python port of markdown-it. Markdown parsing, done right!"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "markdown-it-py-3.0.0.tar.gz", hash = "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb"},
+    {file = "markdown_it_py-3.0.0-py3-none-any.whl", hash = "sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1"},
+]
+
+[package.dependencies]
+mdurl = ">=0.1,<1.0"
+
+[package.extras]
+benchmarking = ["psutil", "pytest", "pytest-benchmark"]
+code-style = ["pre-commit (>=3.0,<4.0)"]
+compare = ["commonmark (>=0.9,<1.0)", "markdown (>=3.4,<4.0)", "mistletoe (>=1.0,<2.0)", "mistune (>=2.0,<3.0)", "panflute (>=2.3,<3.0)"]
+linkify = ["linkify-it-py (>=1,<3)"]
+plugins = ["mdit-py-plugins"]
+profiling = ["gprof2dot"]
+rtd = ["jupyter_sphinx", "mdit-py-plugins", "myst-parser", "pyyaml", "sphinx", "sphinx-copybutton", "sphinx-design", "sphinx_book_theme"]
+testing = ["coverage", "pytest", "pytest-cov", "pytest-regressions"]
+
+[[package]]
 name = "markupsafe"
 version = "3.0.2"
 description = "Safely add untrusted strings to HTML/XML markup."
@@ -636,6 +707,18 @@ files = [
 
 [package.dependencies]
 traitlets = "*"
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+description = "Markdown URL utilities"
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+files = [
+    {file = "mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8"},
+    {file = "mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba"},
+]
 
 [[package]]
 name = "mypy-extensions"
@@ -835,6 +918,24 @@ files = [
 windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
+name = "pygount"
+version = "1.8.0"
+description = "count source lines of code (SLOC) using pygments"
+optional = false
+python-versions = "<3.13,>=3.8"
+groups = ["main"]
+files = [
+    {file = "pygount-1.8.0-py3-none-any.whl", hash = "sha256:bb4e27ae3709674a91e349f503240ffeaef7efa59d1e026c7e4b2278dd3deb7f"},
+    {file = "pygount-1.8.0.tar.gz", hash = "sha256:a1c530a8ff473c99dc7cd24b034f382d60f51efcac3a1d2181642124dbda2173"},
+]
+
+[package.dependencies]
+chardet = ">=5,<6"
+gitpython = ">=3,<4"
+pygments = ">=2,<3"
+rich = ">=9,<14"
+
+[[package]]
 name = "pyre-check"
 version = "0.9.23"
 description = "A performant type checker for Python"
@@ -981,6 +1082,7 @@ files = [
 [package.dependencies]
 attrs = ">=22.2.0"
 rpds-py = ">=0.7.0"
+typing-extensions = {version = ">=4.4.0", markers = "python_version < \"3.13\""}
 
 [[package]]
 name = "requests"
@@ -1005,116 +1107,135 @@ socks = ["PySocks (>=1.5.6,!=1.5.7)"]
 use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
+name = "rich"
+version = "13.9.4"
+description = "Render rich text, tables, progress bars, syntax highlighting, markdown and more to the terminal"
+optional = false
+python-versions = ">=3.8.0"
+groups = ["main"]
+files = [
+    {file = "rich-13.9.4-py3-none-any.whl", hash = "sha256:6049d5e6ec054bf2779ab3358186963bac2ea89175919d699e378b99738c2a90"},
+    {file = "rich-13.9.4.tar.gz", hash = "sha256:439594978a49a09530cff7ebc4b5c7103ef57baf48d5ea3184f21d9a2befa098"},
+]
+
+[package.dependencies]
+markdown-it-py = ">=2.2.0"
+pygments = ">=2.13.0,<3.0.0"
+
+[package.extras]
+jupyter = ["ipywidgets (>=7.5.1,<9)"]
+
+[[package]]
 name = "rpds-py"
-version = "0.22.3"
+version = "0.23.0"
 description = "Python bindings to Rust's persistent data structures (rpds)"
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "rpds_py-0.22.3-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:6c7b99ca52c2c1752b544e310101b98a659b720b21db00e65edca34483259967"},
-    {file = "rpds_py-0.22.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:be2eb3f2495ba669d2a985f9b426c1797b7d48d6963899276d22f23e33d47e37"},
-    {file = "rpds_py-0.22.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:70eb60b3ae9245ddea20f8a4190bd79c705a22f8028aaf8bbdebe4716c3fab24"},
-    {file = "rpds_py-0.22.3-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:4041711832360a9b75cfb11b25a6a97c8fb49c07b8bd43d0d02b45d0b499a4ff"},
-    {file = "rpds_py-0.22.3-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:64607d4cbf1b7e3c3c8a14948b99345eda0e161b852e122c6bb71aab6d1d798c"},
-    {file = "rpds_py-0.22.3-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:81e69b0a0e2537f26d73b4e43ad7bc8c8efb39621639b4434b76a3de50c6966e"},
-    {file = "rpds_py-0.22.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bc27863442d388870c1809a87507727b799c8460573cfbb6dc0eeaef5a11b5ec"},
-    {file = "rpds_py-0.22.3-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e79dd39f1e8c3504be0607e5fc6e86bb60fe3584bec8b782578c3b0fde8d932c"},
-    {file = "rpds_py-0.22.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:e0fa2d4ec53dc51cf7d3bb22e0aa0143966119f42a0c3e4998293a3dd2856b09"},
-    {file = "rpds_py-0.22.3-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:fda7cb070f442bf80b642cd56483b5548e43d366fe3f39b98e67cce780cded00"},
-    {file = "rpds_py-0.22.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:cff63a0272fcd259dcc3be1657b07c929c466b067ceb1c20060e8d10af56f5bf"},
-    {file = "rpds_py-0.22.3-cp310-cp310-win32.whl", hash = "sha256:9bd7228827ec7bb817089e2eb301d907c0d9827a9e558f22f762bb690b131652"},
-    {file = "rpds_py-0.22.3-cp310-cp310-win_amd64.whl", hash = "sha256:9beeb01d8c190d7581a4d59522cd3d4b6887040dcfc744af99aa59fef3e041a8"},
-    {file = "rpds_py-0.22.3-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:d20cfb4e099748ea39e6f7b16c91ab057989712d31761d3300d43134e26e165f"},
-    {file = "rpds_py-0.22.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:68049202f67380ff9aa52f12e92b1c30115f32e6895cd7198fa2a7961621fc5a"},
-    {file = "rpds_py-0.22.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fb4f868f712b2dd4bcc538b0a0c1f63a2b1d584c925e69a224d759e7070a12d5"},
-    {file = "rpds_py-0.22.3-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bc51abd01f08117283c5ebf64844a35144a0843ff7b2983e0648e4d3d9f10dbb"},
-    {file = "rpds_py-0.22.3-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0f3cec041684de9a4684b1572fe28c7267410e02450f4561700ca5a3bc6695a2"},
-    {file = "rpds_py-0.22.3-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7ef9d9da710be50ff6809fed8f1963fecdfecc8b86656cadfca3bc24289414b0"},
-    {file = "rpds_py-0.22.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:59f4a79c19232a5774aee369a0c296712ad0e77f24e62cad53160312b1c1eaa1"},
-    {file = "rpds_py-0.22.3-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1a60bce91f81ddaac922a40bbb571a12c1070cb20ebd6d49c48e0b101d87300d"},
-    {file = "rpds_py-0.22.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e89391e6d60251560f0a8f4bd32137b077a80d9b7dbe6d5cab1cd80d2746f648"},
-    {file = "rpds_py-0.22.3-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:e3fb866d9932a3d7d0c82da76d816996d1667c44891bd861a0f97ba27e84fc74"},
-    {file = "rpds_py-0.22.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:1352ae4f7c717ae8cba93421a63373e582d19d55d2ee2cbb184344c82d2ae55a"},
-    {file = "rpds_py-0.22.3-cp311-cp311-win32.whl", hash = "sha256:b0b4136a252cadfa1adb705bb81524eee47d9f6aab4f2ee4fa1e9d3cd4581f64"},
-    {file = "rpds_py-0.22.3-cp311-cp311-win_amd64.whl", hash = "sha256:8bd7c8cfc0b8247c8799080fbff54e0b9619e17cdfeb0478ba7295d43f635d7c"},
-    {file = "rpds_py-0.22.3-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:27e98004595899949bd7a7b34e91fa7c44d7a97c40fcaf1d874168bb652ec67e"},
-    {file = "rpds_py-0.22.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1978d0021e943aae58b9b0b196fb4895a25cc53d3956b8e35e0b7682eefb6d56"},
-    {file = "rpds_py-0.22.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:655ca44a831ecb238d124e0402d98f6212ac527a0ba6c55ca26f616604e60a45"},
-    {file = "rpds_py-0.22.3-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:feea821ee2a9273771bae61194004ee2fc33f8ec7db08117ef9147d4bbcbca8e"},
-    {file = "rpds_py-0.22.3-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:22bebe05a9ffc70ebfa127efbc429bc26ec9e9b4ee4d15a740033efda515cf3d"},
-    {file = "rpds_py-0.22.3-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3af6e48651c4e0d2d166dc1b033b7042ea3f871504b6805ba5f4fe31581d8d38"},
-    {file = "rpds_py-0.22.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e67ba3c290821343c192f7eae1d8fd5999ca2dc99994114643e2f2d3e6138b15"},
-    {file = "rpds_py-0.22.3-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:02fbb9c288ae08bcb34fb41d516d5eeb0455ac35b5512d03181d755d80810059"},
-    {file = "rpds_py-0.22.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f56a6b404f74ab372da986d240e2e002769a7d7102cc73eb238a4f72eec5284e"},
-    {file = "rpds_py-0.22.3-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:0a0461200769ab3b9ab7e513f6013b7a97fdeee41c29b9db343f3c5a8e2b9e61"},
-    {file = "rpds_py-0.22.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:8633e471c6207a039eff6aa116e35f69f3156b3989ea3e2d755f7bc41754a4a7"},
-    {file = "rpds_py-0.22.3-cp312-cp312-win32.whl", hash = "sha256:593eba61ba0c3baae5bc9be2f5232430453fb4432048de28399ca7376de9c627"},
-    {file = "rpds_py-0.22.3-cp312-cp312-win_amd64.whl", hash = "sha256:d115bffdd417c6d806ea9069237a4ae02f513b778e3789a359bc5856e0404cc4"},
-    {file = "rpds_py-0.22.3-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:ea7433ce7e4bfc3a85654aeb6747babe3f66eaf9a1d0c1e7a4435bbdf27fea84"},
-    {file = "rpds_py-0.22.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:6dd9412824c4ce1aca56c47b0991e65bebb7ac3f4edccfd3f156150c96a7bf25"},
-    {file = "rpds_py-0.22.3-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:20070c65396f7373f5df4005862fa162db5d25d56150bddd0b3e8214e8ef45b4"},
-    {file = "rpds_py-0.22.3-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0b09865a9abc0ddff4e50b5ef65467cd94176bf1e0004184eb915cbc10fc05c5"},
-    {file = "rpds_py-0.22.3-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3453e8d41fe5f17d1f8e9c383a7473cd46a63661628ec58e07777c2fff7196dc"},
-    {file = "rpds_py-0.22.3-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f5d36399a1b96e1a5fdc91e0522544580dbebeb1f77f27b2b0ab25559e103b8b"},
-    {file = "rpds_py-0.22.3-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:009de23c9c9ee54bf11303a966edf4d9087cd43a6003672e6aa7def643d06518"},
-    {file = "rpds_py-0.22.3-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1aef18820ef3e4587ebe8b3bc9ba6e55892a6d7b93bac6d29d9f631a3b4befbd"},
-    {file = "rpds_py-0.22.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f60bd8423be1d9d833f230fdbccf8f57af322d96bcad6599e5a771b151398eb2"},
-    {file = "rpds_py-0.22.3-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:62d9cfcf4948683a18a9aff0ab7e1474d407b7bab2ca03116109f8464698ab16"},
-    {file = "rpds_py-0.22.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9253fc214112405f0afa7db88739294295f0e08466987f1d70e29930262b4c8f"},
-    {file = "rpds_py-0.22.3-cp313-cp313-win32.whl", hash = "sha256:fb0ba113b4983beac1a2eb16faffd76cb41e176bf58c4afe3e14b9c681f702de"},
-    {file = "rpds_py-0.22.3-cp313-cp313-win_amd64.whl", hash = "sha256:c58e2339def52ef6b71b8f36d13c3688ea23fa093353f3a4fee2556e62086ec9"},
-    {file = "rpds_py-0.22.3-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:f82a116a1d03628a8ace4859556fb39fd1424c933341a08ea3ed6de1edb0283b"},
-    {file = "rpds_py-0.22.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3dfcbc95bd7992b16f3f7ba05af8a64ca694331bd24f9157b49dadeeb287493b"},
-    {file = "rpds_py-0.22.3-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:59259dc58e57b10e7e18ce02c311804c10c5a793e6568f8af4dead03264584d1"},
-    {file = "rpds_py-0.22.3-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5725dd9cc02068996d4438d397e255dcb1df776b7ceea3b9cb972bdb11260a83"},
-    {file = "rpds_py-0.22.3-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:99b37292234e61325e7a5bb9689e55e48c3f5f603af88b1642666277a81f1fbd"},
-    {file = "rpds_py-0.22.3-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:27b1d3b3915a99208fee9ab092b8184c420f2905b7d7feb4aeb5e4a9c509b8a1"},
-    {file = "rpds_py-0.22.3-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f612463ac081803f243ff13cccc648578e2279295048f2a8d5eb430af2bae6e3"},
-    {file = "rpds_py-0.22.3-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:f73d3fef726b3243a811121de45193c0ca75f6407fe66f3f4e183c983573e130"},
-    {file = "rpds_py-0.22.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:3f21f0495edea7fdbaaa87e633a8689cd285f8f4af5c869f27bc8074638ad69c"},
-    {file = "rpds_py-0.22.3-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:1e9663daaf7a63ceccbbb8e3808fe90415b0757e2abddbfc2e06c857bf8c5e2b"},
-    {file = "rpds_py-0.22.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:a76e42402542b1fae59798fab64432b2d015ab9d0c8c47ba7addddbaf7952333"},
-    {file = "rpds_py-0.22.3-cp313-cp313t-win32.whl", hash = "sha256:69803198097467ee7282750acb507fba35ca22cc3b85f16cf45fb01cb9097730"},
-    {file = "rpds_py-0.22.3-cp313-cp313t-win_amd64.whl", hash = "sha256:f5cf2a0c2bdadf3791b5c205d55a37a54025c6e18a71c71f82bb536cf9a454bf"},
-    {file = "rpds_py-0.22.3-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:378753b4a4de2a7b34063d6f95ae81bfa7b15f2c1a04a9518e8644e81807ebea"},
-    {file = "rpds_py-0.22.3-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:3445e07bf2e8ecfeef6ef67ac83de670358abf2996916039b16a218e3d95e97e"},
-    {file = "rpds_py-0.22.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7b2513ba235829860b13faa931f3b6846548021846ac808455301c23a101689d"},
-    {file = "rpds_py-0.22.3-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:eaf16ae9ae519a0e237a0f528fd9f0197b9bb70f40263ee57ae53c2b8d48aeb3"},
-    {file = "rpds_py-0.22.3-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:583f6a1993ca3369e0f80ba99d796d8e6b1a3a2a442dd4e1a79e652116413091"},
-    {file = "rpds_py-0.22.3-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4617e1915a539a0d9a9567795023de41a87106522ff83fbfaf1f6baf8e85437e"},
-    {file = "rpds_py-0.22.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0c150c7a61ed4a4f4955a96626574e9baf1adf772c2fb61ef6a5027e52803543"},
-    {file = "rpds_py-0.22.3-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2fa4331c200c2521512595253f5bb70858b90f750d39b8cbfd67465f8d1b596d"},
-    {file = "rpds_py-0.22.3-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:214b7a953d73b5e87f0ebece4a32a5bd83c60a3ecc9d4ec8f1dca968a2d91e99"},
-    {file = "rpds_py-0.22.3-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:f47ad3d5f3258bd7058d2d506852217865afefe6153a36eb4b6928758041d831"},
-    {file = "rpds_py-0.22.3-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:f276b245347e6e36526cbd4a266a417796fc531ddf391e43574cf6466c492520"},
-    {file = "rpds_py-0.22.3-cp39-cp39-win32.whl", hash = "sha256:bbb232860e3d03d544bc03ac57855cd82ddf19c7a07651a7c0fdb95e9efea8b9"},
-    {file = "rpds_py-0.22.3-cp39-cp39-win_amd64.whl", hash = "sha256:cfbc454a2880389dbb9b5b398e50d439e2e58669160f27b60e5eca11f68ae17c"},
-    {file = "rpds_py-0.22.3-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:d48424e39c2611ee1b84ad0f44fb3b2b53d473e65de061e3f460fc0be5f1939d"},
-    {file = "rpds_py-0.22.3-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:24e8abb5878e250f2eb0d7859a8e561846f98910326d06c0d51381fed59357bd"},
-    {file = "rpds_py-0.22.3-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4b232061ca880db21fa14defe219840ad9b74b6158adb52ddf0e87bead9e8493"},
-    {file = "rpds_py-0.22.3-pp310-pypy310_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ac0a03221cdb5058ce0167ecc92a8c89e8d0decdc9e99a2ec23380793c4dcb96"},
-    {file = "rpds_py-0.22.3-pp310-pypy310_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:eb0c341fa71df5a4595f9501df4ac5abfb5a09580081dffbd1ddd4654e6e9123"},
-    {file = "rpds_py-0.22.3-pp310-pypy310_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bf9db5488121b596dbfc6718c76092fda77b703c1f7533a226a5a9f65248f8ad"},
-    {file = "rpds_py-0.22.3-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0b8db6b5b2d4491ad5b6bdc2bc7c017eec108acbf4e6785f42a9eb0ba234f4c9"},
-    {file = "rpds_py-0.22.3-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b3d504047aba448d70cf6fa22e06cb09f7cbd761939fdd47604f5e007675c24e"},
-    {file = "rpds_py-0.22.3-pp310-pypy310_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:e61b02c3f7a1e0b75e20c3978f7135fd13cb6cf551bf4a6d29b999a88830a338"},
-    {file = "rpds_py-0.22.3-pp310-pypy310_pp73-musllinux_1_2_i686.whl", hash = "sha256:e35ba67d65d49080e8e5a1dd40101fccdd9798adb9b050ff670b7d74fa41c566"},
-    {file = "rpds_py-0.22.3-pp310-pypy310_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:26fd7cac7dd51011a245f29a2cc6489c4608b5a8ce8d75661bb4a1066c52dfbe"},
-    {file = "rpds_py-0.22.3-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:177c7c0fce2855833819c98e43c262007f42ce86651ffbb84f37883308cb0e7d"},
-    {file = "rpds_py-0.22.3-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:bb47271f60660803ad11f4c61b42242b8c1312a31c98c578f79ef9387bbde21c"},
-    {file = "rpds_py-0.22.3-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:70fb28128acbfd264eda9bf47015537ba3fe86e40d046eb2963d75024be4d055"},
-    {file = "rpds_py-0.22.3-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:44d61b4b7d0c2c9ac019c314e52d7cbda0ae31078aabd0f22e583af3e0d79723"},
-    {file = "rpds_py-0.22.3-pp39-pypy39_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5f0e260eaf54380380ac3808aa4ebe2d8ca28b9087cf411649f96bad6900c728"},
-    {file = "rpds_py-0.22.3-pp39-pypy39_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b25bc607423935079e05619d7de556c91fb6adeae9d5f80868dde3468657994b"},
-    {file = "rpds_py-0.22.3-pp39-pypy39_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:fb6116dfb8d1925cbdb52595560584db42a7f664617a1f7d7f6e32f138cdf37d"},
-    {file = "rpds_py-0.22.3-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a63cbdd98acef6570c62b92a1e43266f9e8b21e699c363c0fef13bd530799c11"},
-    {file = "rpds_py-0.22.3-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2b8f60e1b739a74bab7e01fcbe3dddd4657ec685caa04681df9d562ef15b625f"},
-    {file = "rpds_py-0.22.3-pp39-pypy39_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:2e8b55d8517a2fda8d95cb45d62a5a8bbf9dd0ad39c5b25c8833efea07b880ca"},
-    {file = "rpds_py-0.22.3-pp39-pypy39_pp73-musllinux_1_2_i686.whl", hash = "sha256:2de29005e11637e7a2361fa151f780ff8eb2543a0da1413bb951e9f14b699ef3"},
-    {file = "rpds_py-0.22.3-pp39-pypy39_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:666ecce376999bf619756a24ce15bb14c5bfaf04bf00abc7e663ce17c3f34fe7"},
-    {file = "rpds_py-0.22.3-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:5246b14ca64a8675e0a7161f7af68fe3e910e6b90542b4bfb5439ba752191df6"},
-    {file = "rpds_py-0.22.3.tar.gz", hash = "sha256:e32fee8ab45d3c2db6da19a5323bc3362237c8b653c70194414b892fd06a080d"},
+    {file = "rpds_py-0.23.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:1b36e993b95f0744a94a5add7624cfaf77b91805819c1a960026bc452f95841e"},
+    {file = "rpds_py-0.23.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:72a0dd4d599fadaf519d4e4b8092e5d7940057c61e70f9f06c1d004a47895204"},
+    {file = "rpds_py-0.23.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bba83d703c6728a3a2676a14a9649d7cc87b9e4654293f13f8d4b4d7007d6383"},
+    {file = "rpds_py-0.23.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:1191bf5975a0b001c161a62d5833a6b2f838b10ff19e203910dd6210e88d89f5"},
+    {file = "rpds_py-0.23.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3154e132e685f907813ace8701721ad4420244f6e07afc2a61763894e8a22961"},
+    {file = "rpds_py-0.23.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:62d8fe953110a98a118cacdc1ca79fe344a946c72a2d19fa7d17d0b2ace58f3d"},
+    {file = "rpds_py-0.23.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2e27dfcea222c81cd8bece98a73ebb8ca69870de01dc27002d433ad06e55dd8b"},
+    {file = "rpds_py-0.23.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7cca21adfefe5a2237f1e64d769c1ed7ccdc2515d376d1774e7fbe918e03cd8c"},
+    {file = "rpds_py-0.23.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:8c708f5c2d604e0acc9489df3ea879f4fc75030dfa590668fd959fda34fcc0b8"},
+    {file = "rpds_py-0.23.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:c23cbff21154951731866358e983d01d536a2c0f60f2765be85f00682eae60d9"},
+    {file = "rpds_py-0.23.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:16826a5346e293bedf0acd5c2f4c8e05415b1970aa3cc448eea19f02724dd453"},
+    {file = "rpds_py-0.23.0-cp310-cp310-win32.whl", hash = "sha256:1e0fb88357f59c70b8595bc8e5887be35636e646a9ab519c1876063159812cf6"},
+    {file = "rpds_py-0.23.0-cp310-cp310-win_amd64.whl", hash = "sha256:c79544d0be2c7c3891fe448bc006666410bc219fdf29bf35990f0ea88ff72b64"},
+    {file = "rpds_py-0.23.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:827b334702a04df2e1b7fe85ed3784512f6fd3d3a40259180db0c8fdeb20b37f"},
+    {file = "rpds_py-0.23.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:0e1ece346395e127a8024e5c13d304bdd7dbd094e05329a2f4f27ea1fbe14aa3"},
+    {file = "rpds_py-0.23.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3adc0b2e71e62fde524389634df4b53f4d16d5f3830ab35c1e511d50b75674f6"},
+    {file = "rpds_py-0.23.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b1eb4757f9c9f96e26a420db97c3ecaa97568961ce718f1f89e03ce1f59ec12e"},
+    {file = "rpds_py-0.23.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e17402e8f3b49a7ec22e7ef7bbbe0ac0797fcbf0f1ba844811668ef24b37fc9d"},
+    {file = "rpds_py-0.23.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8212c5d25514386a14a032fde7f7f0383a88355f93a1d0fde453f38ebdc43a1b"},
+    {file = "rpds_py-0.23.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5211b646a0beb1f8f4b1cde8c7c073f9d6ca3439d5a93ea0874c8ece6cab66a9"},
+    {file = "rpds_py-0.23.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:83f71359d81cfb3bd39522045d08a7031036fb0b1b0a43a066c094cc52a9fd00"},
+    {file = "rpds_py-0.23.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:9e66aaa24e0dc3cfaf63a8fc2810ae296792c18fb4cfb99868f52e7c598911b6"},
+    {file = "rpds_py-0.23.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:35336790b4d70c31a59c922d7d603010fe13c5ff56a1dce14849b6bb6a2ad4b9"},
+    {file = "rpds_py-0.23.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:377ba75ebce48d5df69b0ab2e3333cd86f6acfee8cf0a2c286af4e32e4a8b499"},
+    {file = "rpds_py-0.23.0-cp311-cp311-win32.whl", hash = "sha256:784a79474675ee12cab90241f3df328129e15443acfea618df069a7d67d12abb"},
+    {file = "rpds_py-0.23.0-cp311-cp311-win_amd64.whl", hash = "sha256:f1023b1de400ef9d3d9f8f9e88f3f5d8c66c26e48c3f83cffe83bd423def8d81"},
+    {file = "rpds_py-0.23.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:d1f3baf652aeb91775eb3343535890156b07e0cbb2a7b72651f4bbaf7323d40f"},
+    {file = "rpds_py-0.23.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6593dc9b225f8fc900df43c40625c998b8fa99ba78ec69bcd073fe3fb1018a5d"},
+    {file = "rpds_py-0.23.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:75d5a2c5629e3582aa73c3a11ac0a3dd454e86cc70188a9b6e2ed51889c331dd"},
+    {file = "rpds_py-0.23.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:64ba22924340d7e200b48befcc75ff2379301902381ca4ebbfec81d80c5216b5"},
+    {file = "rpds_py-0.23.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:04d7fc114ca57d25f0d8c324d2d0ddd675df92b2f7da8284f806711c25fe00f7"},
+    {file = "rpds_py-0.23.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5ff50d7a5b206af7ac8342255ae3ab6c6c86d86520f4413bf9d2561bf4f1ffa1"},
+    {file = "rpds_py-0.23.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3b147c0d49de69dac573c8e05a5f7edf18a83136bf8c98e2cd3e87dafee184e5"},
+    {file = "rpds_py-0.23.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5bc79d528e65c877a5e254ddad394d51797bc6bba44c9aa436f61b94448d5f87"},
+    {file = "rpds_py-0.23.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:ce1a2fe8eea2e956a11112ba426b9be79b2da65e27a533cf152ba8e9882bf9be"},
+    {file = "rpds_py-0.23.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:e2c26f1e0ebbe85dc275816cd53fcbb225aaf7923a4d48b7cdf8b8eb6291e5ae"},
+    {file = "rpds_py-0.23.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6893a88925972635c843eb02a113d7aabacd386c05d54f2fda29125befbc1b05"},
+    {file = "rpds_py-0.23.0-cp312-cp312-win32.whl", hash = "sha256:06962dc9462fe97d0355e01525ebafcd317316e80e335272751a1857b7bdec97"},
+    {file = "rpds_py-0.23.0-cp312-cp312-win_amd64.whl", hash = "sha256:04882cc4adbdc2778dd49f5ed71b1d9ab43349c45cde7e461456d0432d7d323e"},
+    {file = "rpds_py-0.23.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:c46247ea1382758987417b9c47b05d32dc7f971cd2553e7b3088a76ad48c5a67"},
+    {file = "rpds_py-0.23.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:fa93e2460b7791872a5dd355438b854a5d9ab317107380c2143d94a1ca5b10a7"},
+    {file = "rpds_py-0.23.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:784d2ef454b42451a1efca40f888105536b6d2374d155c14f51831980c384461"},
+    {file = "rpds_py-0.23.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:aae64cb7faaecd5d36ebcb99dc3f0196f4357586e095630207047f35183431fb"},
+    {file = "rpds_py-0.23.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d8c754d4d021a010df79e0ce10b2dbf0ed12997ff4e508274337fdceed32275f"},
+    {file = "rpds_py-0.23.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:96f0261ef2a45c9dc48c4105ab798e8ba1c0c912ae5c59c2d9f899242cf3ed79"},
+    {file = "rpds_py-0.23.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3cb0ddf0ecc705f8f6dfe858e703c1b9b3ea240b1f56e33316e89dc6c2994ac0"},
+    {file = "rpds_py-0.23.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c7fee301c715ce2fed4c0620a65dff12686002061cd38c6f11a427f64bd0c8ff"},
+    {file = "rpds_py-0.23.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:aef4f05059aa6f5f22c76f23f45b6908da4871589c9efb882e58c33ebf8f4c4f"},
+    {file = "rpds_py-0.23.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:77c3e51d994c39227facc742001b7be98c2ad634f8a0cf2ed08c30cf2f7f9249"},
+    {file = "rpds_py-0.23.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9901d57e8dc3b7245d349a255af097e309602986a604d073414a3826bc5c2cdd"},
+    {file = "rpds_py-0.23.0-cp313-cp313-win32.whl", hash = "sha256:56bbf34e129551004e4952db16087bb4912e8cf4fa335ad5c70e126666f97788"},
+    {file = "rpds_py-0.23.0-cp313-cp313-win_amd64.whl", hash = "sha256:fbeade9f0284a5c5965f8a4805ef1864e5fb4bc4c5d3d8dd60c5fd2a44f0b51a"},
+    {file = "rpds_py-0.23.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:c5e3c7d7cdbbd450acb62c5d29d39ea6d5f8584019d391947d73fb998f54acc5"},
+    {file = "rpds_py-0.23.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:d59582ddbeabf217d1b815b60acaec9ff5e2ded79e440c3b3e4ddc970ff59160"},
+    {file = "rpds_py-0.23.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6097538c81a94d4432de645a20bbbbfa7a0eb52c6dcb7370feda18eb8eed61de"},
+    {file = "rpds_py-0.23.0-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ac766c8127ee9c9a72f1a6ad6b4291e5acfd14d9685964b771bf8820fe65aeed"},
+    {file = "rpds_py-0.23.0-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0edf94328feaae49a96caa3459784614365708c38f610316601b996e5f085be1"},
+    {file = "rpds_py-0.23.0-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0f74d8babe0139b8ee30c24c65040cdad81e00547e7eefe43d13b31da9d2bbc5"},
+    {file = "rpds_py-0.23.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cf06007aca17ea31069adc8396d718b714559fd7f7db8302399b4697c4564fec"},
+    {file = "rpds_py-0.23.0-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:9b263adb8e54bc7a5b2b8feebe99ff79f1067037a9178989e9341ea76e935706"},
+    {file = "rpds_py-0.23.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:516cec4c1a45bed3c417c402a2f52515561a1d8e578ff675347dcf4180636cca"},
+    {file = "rpds_py-0.23.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:37af2ee37efeb0a09463124cc1e560192cc751c2a5ae650effb36469e1f17dc8"},
+    {file = "rpds_py-0.23.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:312981d4da5dc463baeca3ba23a3e74dc7a48a4500d267566d8e9c0680ac54c6"},
+    {file = "rpds_py-0.23.0-cp313-cp313t-win32.whl", hash = "sha256:ce1c4277d7f235faa2f31f1aad82e3ab3caeb66f13c97413e738592ec7fef7e0"},
+    {file = "rpds_py-0.23.0-cp313-cp313t-win_amd64.whl", hash = "sha256:f46d53a6a37383eca41a111df0e9993399a60e9e1e2110f467fddc5de4a43b68"},
+    {file = "rpds_py-0.23.0-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:d5504bd1d637e7633d953418520d9b109b0d8a419153a56537938adf068da9d5"},
+    {file = "rpds_py-0.23.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:7730442bb642748dddfbe1de24275bf0cdbae938c68e1c38e0a9d285a056e17d"},
+    {file = "rpds_py-0.23.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:374d2c0067f5ef18e73bfb2a555ef0b8f2b01f5b653a3eca68e9fbde5625c305"},
+    {file = "rpds_py-0.23.0-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a8983725590ddeb62acf7e585badb7354fa71e3d08d3326eaac6886aa91e526c"},
+    {file = "rpds_py-0.23.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:048dc18eb2cc83a67bec07c6f9ffe1da83fb94d5af6cc32e333248013576dc4c"},
+    {file = "rpds_py-0.23.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f4b699830ced68db4294e2e47f25a4ff935a54244814b76fa683e0b857391e3e"},
+    {file = "rpds_py-0.23.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1fa3476c9845152091f62edca5e543df77fc0fc2e83027c389fa4c4f52633369"},
+    {file = "rpds_py-0.23.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c6c98bde8ec93dd4e19c413e3ac089fb0ff731da54bab8aaf1e8263f55f01406"},
+    {file = "rpds_py-0.23.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:947db56d8ee2f567a597f7484ac6c8cb94529181eaa498bd9c196079c395c69f"},
+    {file = "rpds_py-0.23.0-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:a20fa5cd1cb074c145c3955732cfc3eca19bef16d425b32f14c3d275230110fb"},
+    {file = "rpds_py-0.23.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:f27867c24f0a81065ef94e575dbb1846867257994ac41ebbe5e66c6a3976ac73"},
+    {file = "rpds_py-0.23.0-cp39-cp39-win32.whl", hash = "sha256:5e549c7ef1ae42b79878bff27c33363b2de77f23de2f4c19541ef69ae4c11ac7"},
+    {file = "rpds_py-0.23.0-cp39-cp39-win_amd64.whl", hash = "sha256:0b3b3553d9216153eb3f8cf0d369b0e31e83912e50835ee201794d9b410e227f"},
+    {file = "rpds_py-0.23.0-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:b233a2bdb15dbb4c05b0c79c94d2367a05d0c54351b76c74fdc81aae023a2df8"},
+    {file = "rpds_py-0.23.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:d2e0cace96976f4e86fc3c51cb3fba24225976e26341e958be42f3d8d0a634ee"},
+    {file = "rpds_py-0.23.0-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:210aa7c699cc61320630c4be33348d9bfef4785fabd6f33ea6be711d4eb45f1f"},
+    {file = "rpds_py-0.23.0-pp310-pypy310_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7cd550ee493adab33e95ce00cb42529b0435c916ed949d298887ee9acdcd3f2f"},
+    {file = "rpds_py-0.23.0-pp310-pypy310_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:174602fe067a5b622ce47a5b09022e0128c526a308354abd9cc4bf0391f3cfd2"},
+    {file = "rpds_py-0.23.0-pp310-pypy310_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b8b7b4e5cc5a981a147e1602cf4bd517e57617f9a4c7e96a22a27e4d18de2523"},
+    {file = "rpds_py-0.23.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:aa9d67acbcf2cb11acd44da7d41a0495b7799a32fb7ec9a6bc0b14d8552e00fb"},
+    {file = "rpds_py-0.23.0-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:f482453aeebdae7774781e8c9b1884e0df0bdb1c61f330f95c63a401dfc2fc31"},
+    {file = "rpds_py-0.23.0-pp310-pypy310_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:eb841a8e1c2615dfc721d3c28fe81e6300e819a01d3305ecd7f75c7d58c31b2b"},
+    {file = "rpds_py-0.23.0-pp310-pypy310_pp73-musllinux_1_2_i686.whl", hash = "sha256:41f6bb731bfcbd886bd6399717971dd881d759ea831b9f513bc57a10f52c7d53"},
+    {file = "rpds_py-0.23.0-pp310-pypy310_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:a49aeb989ee5e057137910059610bfa8f571a4af674404ce05c59862bbeeecbe"},
+    {file = "rpds_py-0.23.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:670c29a74f8e632aa58b48425b12d026703af1ea5e3b131adbb2601c7ae03108"},
+    {file = "rpds_py-0.23.0-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:e5305ee98053a0f0155e4e5f9fe4d196fa2e43ae7c2ecc61534babf6390511d9"},
+    {file = "rpds_py-0.23.0-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:903344afbc46dfb488a73a7eeb9c14d8484c6d80eb402e6737a520a55327f26c"},
+    {file = "rpds_py-0.23.0-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:87b8e416f55f2be671d5dbf55e7517a8144f8b926609d2f1427f8310c95e4e13"},
+    {file = "rpds_py-0.23.0-pp39-pypy39_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8529a28b0dffe7e0c56537912ab8594df7b71b24032622aadce33a2643beada5"},
+    {file = "rpds_py-0.23.0-pp39-pypy39_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:55fe404f2826c5821661e787dffcb113e682d9ff011d9d39a28c992312d7029b"},
+    {file = "rpds_py-0.23.0-pp39-pypy39_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1bda53037dcac2465d0b2067a7129283eb823c7e0175c0991ea7e28ae7593555"},
+    {file = "rpds_py-0.23.0-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7c2ba6b0f4eccf3738a03878c13f18037931c947d70a75231448954e42884feb"},
+    {file = "rpds_py-0.23.0-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:95d7ffa91b423c974fb50384561736aa16f5fb7a8592d81b2ca5fcaf8afd69a0"},
+    {file = "rpds_py-0.23.0-pp39-pypy39_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:c1523dae0321bf21d0e4151a7438c9bd26c0b712602fb56116efd4ee5b463b5d"},
+    {file = "rpds_py-0.23.0-pp39-pypy39_pp73-musllinux_1_2_i686.whl", hash = "sha256:cec9feef63e213ec9f9cac44d8454643983c422b318b67059da796f55780b4d4"},
+    {file = "rpds_py-0.23.0-pp39-pypy39_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:f9c49366f19c06ce31af1312ae4718292081e73f454a56705e7d56acfd25ac1e"},
+    {file = "rpds_py-0.23.0-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:f119176191c359cb33ff8064b242874bfb1352761379bca8e6ccb74a6141db27"},
+    {file = "rpds_py-0.23.0.tar.gz", hash = "sha256:ffac3b13182dc1bf648cde2982148dc9caf60f3eedec7ae639e05636389ebf5d"},
 ]
 
 [[package]]
@@ -1138,6 +1259,18 @@ doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "pygments-
 enabler = ["pytest-enabler (>=2.2)"]
 test = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "ini2toml[lite] (>=0.14)", "jaraco.develop (>=7.21)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.7.2)", "jaraco.test (>=5.5)", "packaging (>=24.2)", "pip (>=19.1)", "pyproject-hooks (!=1.1)", "pytest (>=6,!=8.1.*)", "pytest-home (>=0.5)", "pytest-perf", "pytest-subprocess", "pytest-timeout", "pytest-xdist (>=3)", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel (>=0.44.0)"]
 type = ["importlib_metadata (>=7.0.2)", "jaraco.develop (>=7.21)", "mypy (==1.14.*)", "pytest-mypy"]
+
+[[package]]
+name = "smmap"
+version = "5.0.2"
+description = "A pure Python implementation of a sliding window memory map manager"
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+files = [
+    {file = "smmap-5.0.2-py3-none-any.whl", hash = "sha256:b30115f0def7d7531d22a0fb6502488d879e75b260a9db4d0819cfb25403af5e"},
+    {file = "smmap-5.0.2.tar.gz", hash = "sha256:26ea65a03958fa0c8a1c7e8c7a58fdc77221b8910f6be2131affade476898ad5"},
+]
 
 [[package]]
 name = "stack-data"
@@ -1244,7 +1377,7 @@ version = "4.12.2"
 description = "Backported and Experimental Type Hints for Python 3.8+"
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "typing_extensions-4.12.2-py3-none-any.whl", hash = "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d"},
     {file = "typing_extensions-4.12.2.tar.gz", hash = "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8"},
@@ -1301,5 +1434,5 @@ coverage = ["coverage", "pybadges", "setuptools", "standard-imghdr"]
 
 [metadata]
 lock-version = "2.1"
-python-versions = ">=3.13"
-content-hash = "758bca4ca12d45c29881cb4be1b2a3936d19c161a8d43ae76bc5fe48cc16313c"
+python-versions = ">=3.12.0,<3.13.0"
+content-hash = "fe3f86ebbaecaf7989783b9a624441386cd76e7744d076937c8f21c42b8e3aed"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,11 +6,12 @@ authors = [
     {name = "Iain-S",email = "25081046+Iain-S@users.noreply.github.com "}
 ]
 readme = "README.md"
-requires-python = ">=3.13"
+requires-python = ">=3.12.0,<3.13.0"
 dependencies = [
     "ipython (>=8.32.0,<9.0.0)",
     "nbformat (>=5.10.4,<6.0.0)",
     "pybadges (>=3.0.1,<4.0.0)",
+    "pygount (>=1.8.0,<2.0.0)",
 ]
 
 [project.optional-dependencies]
@@ -29,8 +30,8 @@ coverage = "^7.6.12"
 line-length = 120
 indent-width = 4
 
-# Assume Python 3.13
-target-version = "py313"
+# Assume Python 3.12
+target-version = "py312"
 
 [tool.ruff.lint]
 # 1. Enable flake8-bugbear (`B`) rules, in addition to the defaults.

--- a/stubs/pygount.pyi
+++ b/stubs/pygount.pyi
@@ -1,0 +1,19 @@
+"""Enough type stubs to satisfy Pyre."""
+
+from pathlib import Path
+
+class ProjectSummary:
+    """Just a type stub."""
+
+    total_code_count: int
+
+    def add(self, analysis: SourceAnalysis) -> None:
+        """Just a type stub."""
+
+class SourceAnalysis:
+    """Just a type stub."""
+
+    @staticmethod
+    def from_file(filepath: Path, name: str) -> SourceAnalysis:
+        """Just a type stub."""
+        return SourceAnalysis()

--- a/tests/EXPECTED_README.md
+++ b/tests/EXPECTED_README.md
@@ -4,28 +4,28 @@ A sentence.
 
 ## Stats
 
-| day | language | who | part | time (s) | mem (KiB) | notes |
-| --- | --- | --- | --- | --- | --- | --- |
-| y | python | iain | one | x | z |  |
-| y | python | iain | two | x | z |  |
-| y | fsharp | iain | one | x | z |  |
-| y | fsharp | iain | two |  |  | Different answer |
-| y | go | iain | one | x | z |  |
-| y | go | iain | two | x | z |  |
-| y | haskell | iain | one | x | z |  |
-| y | haskell | iain | two |  |  | Different answer |
-| y | jupyter | iain | one | x | z |  |
-| y | jupyter | iain | two |  |  | Different answer |
-| y | ocaml | iain | one | x | z |  |
-| y | ocaml | iain | two |  |  | Different answer |
-| y | python | iain | one | x | z |  |
-| y | python | iain | two | x | z |  |
-| y | python | zain | one |  |  | Error(z) |
-| y | python | zain | two |  |  | Error(z) |
-| y | racket | iain | one | x | z |  |
-| y | racket | iain | two |  |  | Different answer |
-| y | rust | iain | one | x | z |  |
-| y | rust | iain | two |  |  | Different answer |
+| day | language | who | lines | part | time (s) | mem (KiB) | notes |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| y | python | iain | a | one | x | z |  |
+| y | python | iain | a | two | x | z |  |
+| y | fsharp | iain | a | one | x | z |  |
+| y | fsharp | iain | a | two |  |  | Different answer |
+| y | go | iain | a | one | x | z |  |
+| y | go | iain | a | two | x | z |  |
+| y | haskell | iain | a | one | x | z |  |
+| y | haskell | iain | a | two |  |  | Different answer |
+| y | jupyter | iain | a | one | x | z |  |
+| y | jupyter | iain | a | two |  |  | Different answer |
+| y | ocaml | iain | a | one | x | z |  |
+| y | ocaml | iain | a | two |  |  | Different answer |
+| y | python | iain | a | one | x | z |  |
+| y | python | iain | a | two | x | z |  |
+| y | python | zain | a | one |  |  | Error(z) |
+| y | python | zain | a | two |  |  | Error(z) |
+| y | racket | iain | a | one | x | z |  |
+| y | racket | iain | a | two |  |  | Different answer |
+| y | rust | iain | a | one | x | z |  |
+| y | rust | iain | a | two |  |  | Different answer |
 
 
 ## Section

--- a/tests/EXPECTED_README_2.md
+++ b/tests/EXPECTED_README_2.md
@@ -4,12 +4,12 @@ A sentence.
 
 ## Stats
 
-| day | language | who | part | time (s) | mem (KiB) | notes |
-| --- | --- | --- | --- | --- | --- | --- |
-| 00 | python | iain | one | 2.34 | 1999 |  |
-| 00 | python | iain | two | 2.34 | 1999 |  |
-| 01 | python | iain | one | 0.01 | 1792 |  |
-| 01 | python | iain | two | 0.01 | 1792 |  |
+| day | language | who | lines | part | time (s) | mem (KiB) | notes |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| 00 | python | iain | 3 | one | 2.34 | 1999 |  |
+| 00 | python | iain | 3 | two | 2.34 | 1999 |  |
+| 01 | python | iain | 3 | one | 0.01 | 1792 |  |
+| 01 | python | iain | 3 | two | 0.01 | 1792 |  |
 
 
 ## Section

--- a/tests/EXPECTED_README_3.md
+++ b/tests/EXPECTED_README_3.md
@@ -5,7 +5,7 @@ A sentence.
 
 ## Stats
 
-| day | language | who | part | time (s) | mem (KiB) | notes |
-| --- | --- | --- | --- | --- | --- | --- |
-| 01 | python | iain | one | 0.01 | 1792 |  |
-| 01 | python | iain | two | 0.01 | 1792 |  |
+| day | language | who | lines | part | time (s) | mem (KiB) | notes |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| 01 | python | iain | 8 | one | 0.01 | 1792 |  |
+| 01 | python | iain | 8 | two | 0.01 | 1792 |  |

--- a/tests/EXPECTED_README_4.md
+++ b/tests/EXPECTED_README_4.md
@@ -4,28 +4,28 @@ A sentence.
 
 ## Stats
 
-| day | language | who | part | time (s) | mem (KiB) | notes |
-| --- | --- | --- | --- | --- | --- | --- |
-| y | python | iain | one | x | z |  |
-| y | python | iain | two | x | z |  |
-| y | fsharp | iain | one | x | z |  |
-| y | fsharp | iain | two |  |  | Different answer |
-| y | go | iain | one | x | z |  |
-| y | go | iain | two | x | z |  |
-| y | haskell | iain | one | x | z |  |
-| y | haskell | iain | two |  |  | Different answer |
-| y | jupyter | iain | one | x | z |  |
-| y | jupyter | iain | two |  |  | Different answer |
-| y | ocaml | iain | one |  |  | Error(z) |
-| y | ocaml | iain | two |  |  | Error(z) |
-| y | python | iain | one | x | z |  |
-| y | python | iain | two | x | z |  |
-| y | python | zain | one |  |  | Error(z) |
-| y | python | zain | two |  |  | Error(z) |
-| y | racket | iain | one |  |  | Error(z) |
-| y | racket | iain | two |  |  | Error(z) |
-| y | rust | iain | one | x | z |  |
-| y | rust | iain | two |  |  | Different answer |
+| day | language | who | lines | part | time (s) | mem (KB) | notes |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| y | python | iain | 8 | one | x | z |  |
+| y | python | iain | 8 | two | x | z |  |
+| y | fsharp | iain | 8 | one | x | z |  |
+| y | fsharp | iain | 8 | two |  |  | Different answer |
+| y | go | iain | one | 8 | x | z |  |
+| y | go | iain | two | 8 | x | z |  |
+| y | haskell | iain | 8 | one | x | z |  |
+| y | haskell | iain | 8 | two |  |  | Different answer |
+| y | jupyter | iain | 8 | one | x | z |  |
+| y | jupyter | iain | 8 | two |  |  | Different answer |
+| y | ocaml | iain | 8 | one |  |  | Error(z) |
+| y | ocaml | iain | 8 | two |  |  | Error(z) |
+| y | python | iain | 8 | one | x | z |  |
+| y | python | iain | 8 | two | x | z |  |
+| y | python | zain | 8 | one |  |  | Error(z) |
+| y | python | zain | 8 | two |  |  | Error(z) |
+| y | racket | iain | 8 | one |  |  | Error(z) |
+| y | racket | iain | 8 | two |  |  | Error(z) |
+| y | rust | iain | 8 | one | x | z |  |
+| y | rust | iain | 8 | two |  |  | Different answer |
 
 
 ## Section

--- a/tests/EXPECTED_README_4.md
+++ b/tests/EXPECTED_README_4.md
@@ -4,7 +4,7 @@ A sentence.
 
 ## Stats
 
-| day | language | who | lines | part | time (s) | mem (KB) | notes |
+| day | language | who | lines | part | time (s) | mem (KiB) | notes |
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | y | python | iain | a | one | x | z |  |
 | y | python | iain | a | two | x | z |  |

--- a/tests/EXPECTED_README_4.md
+++ b/tests/EXPECTED_README_4.md
@@ -6,26 +6,26 @@ A sentence.
 
 | day | language | who | lines | part | time (s) | mem (KB) | notes |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| y | python | iain | 8 | one | x | z |  |
-| y | python | iain | 8 | two | x | z |  |
-| y | fsharp | iain | 8 | one | x | z |  |
-| y | fsharp | iain | 8 | two |  |  | Different answer |
-| y | go | iain | one | 8 | x | z |  |
-| y | go | iain | two | 8 | x | z |  |
-| y | haskell | iain | 8 | one | x | z |  |
-| y | haskell | iain | 8 | two |  |  | Different answer |
-| y | jupyter | iain | 8 | one | x | z |  |
-| y | jupyter | iain | 8 | two |  |  | Different answer |
-| y | ocaml | iain | 8 | one |  |  | Error(z) |
-| y | ocaml | iain | 8 | two |  |  | Error(z) |
-| y | python | iain | 8 | one | x | z |  |
-| y | python | iain | 8 | two | x | z |  |
-| y | python | zain | 8 | one |  |  | Error(z) |
-| y | python | zain | 8 | two |  |  | Error(z) |
-| y | racket | iain | 8 | one |  |  | Error(z) |
-| y | racket | iain | 8 | two |  |  | Error(z) |
-| y | rust | iain | 8 | one | x | z |  |
-| y | rust | iain | 8 | two |  |  | Different answer |
+| y | python | iain | a | one | x | z |  |
+| y | python | iain | a | two | x | z |  |
+| y | fsharp | iain | a | one | x | z |  |
+| y | fsharp | iain | a | two |  |  | Different answer |
+| y | go | iain | one | a | x | z |  |
+| y | go | iain | two | a | x | z |  |
+| y | haskell | iain | a | one | x | z |  |
+| y | haskell | iain | a | two |  |  | Different answer |
+| y | jupyter | iain | a | one | x | z |  |
+| y | jupyter | iain | a | two |  |  | Different answer |
+| y | ocaml | iain | a | one |  |  | Error(z) |
+| y | ocaml | iain | a | two |  |  | Error(z) |
+| y | python | iain | a | one | x | z |  |
+| y | python | iain | a | two | x | z |  |
+| y | python | zain | a | one |  |  | Error(z) |
+| y | python | zain | a | two |  |  | Error(z) |
+| y | racket | iain | a | one |  |  | Error(z) |
+| y | racket | iain | a | two |  |  | Error(z) |
+| y | rust | iain | a | one | x | z |  |
+| y | rust | iain | a | two |  |  | Different answer |
 
 
 ## Section

--- a/tests/EXPECTED_README_4.md
+++ b/tests/EXPECTED_README_4.md
@@ -10,8 +10,8 @@ A sentence.
 | y | python | iain | a | two | x | z |  |
 | y | fsharp | iain | a | one | x | z |  |
 | y | fsharp | iain | a | two |  |  | Different answer |
-| y | go | iain | one | a | x | z |  |
-| y | go | iain | two | a | x | z |  |
+| y | go | iain | a | one | x | z |  |
+| y | go | iain | a | two | x | z |  |
 | y | haskell | iain | a | one | x | z |  |
 | y | haskell | iain | a | two |  |  | Different answer |
 | y | jupyter | iain | a | one | x | z |  |

--- a/tests/README_TEMPLATE.md
+++ b/tests/README_TEMPLATE.md
@@ -4,10 +4,10 @@ A sentence.
 
 ## Stats
 
-| day | language | who | part | time | mem | notes |
-| --- | --- | --- | --- | --- | --- | --- |
-| 00 | python | iain | one | 2.34 | 1999 |  |
-| 00 | python | iain | two | 2.34 | 1999 |  |
+| day | language | who | lines | part | time | mem | notes |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| 00 | python | iain | 3 | one | 2.34 | 1999 |  |
+| 00 | python | iain | 3 | two | 2.34 | 1999 |  |
 
 ## Section
 

--- a/tests/README_TEMPLATE_3.md
+++ b/tests/README_TEMPLATE_3.md
@@ -4,23 +4,23 @@ A sentence.
 
 ## Stats
 
-| day | language | who | part | time (s) | mem (KiB) | notes |
-| --- | --- | --- | --- | --- | --- | --- |
-| 99 | go | iain | one | 1 | 8 |  |
-| 99 | go | iain | two |  |  | Different answer |
-| 99 | haskell | iain | one | 1 | 8 |  |
-| 99 | haskell | iain | two |  |  | Different answer |
-| 99 | jupyter | iain | one | 1 | 8 |  |
-| 99 | jupyter | iain | two |  |  | Different answer |
-| 99 | ocaml | iain | one | 1 | 8 |  |
-| 99 | ocaml | iain | two |  |  | Different answer |
-| 99 | python | iain | one | 1 | 8 |  |
-| 99 | python | iain | two | 1 | 8 |  |
-| 99 | python | zain | one |  |  | Error(z) |
-| 99 | python | zain | two |  |  | Error(z) |
-| 99 | racket | iain | one | 1 | 8 |  |
-| 99 | racket | iain | two |  |  | Different answer |
-| 99 | rust | iain | one | 1 | 8 |  |
+| day | language | who | lines | part | time (s) | mem (KiB) | notes |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| 99 | go | iain | 8 | one | 1 | 8 |  |
+| 99 | go | iain | 8 | two |  |  | Different answer |
+| 99 | haskell | iain | 8 | one | 1 | 8 |  |
+| 99 | haskell | iain | 8 | two |  |  | Different answer |
+| 99 | jupyter | iain | 8 | one | 1 | 8 |  |
+| 99 | jupyter | iain | 8 | two |  |  | Different answer |
+| 99 | ocaml | iain | 8 | one | 1 | 8 |  |
+| 99 | ocaml | iain | 8 | two |  |  | Different answer |
+| 99 | python | iain | 8 | one | 1 | 8 |  |
+| 99 | python | iain | 8 | two | 1 | 8 |  |
+| 99 | python | zain | 8 | one |  |  | Error(z) |
+| 99 | python | zain | 8 | two |  |  | Error(z) |
+| 99 | racket | iain | 8 | one | 1 | 8 |  |
+| 99 | racket | iain | 8 | two |  |  | Different answer |
+| 99 | rust | iain | 8 | one | 1 | 8 |  |
 
 
 ## Section

--- a/tests/day_99/python_zain/does_nothing.py
+++ b/tests/day_99/python_zain/does_nothing.py
@@ -1,0 +1,3 @@
+"""To check our code line count."""
+
+print("hi")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -339,9 +339,9 @@ class TestMain(unittest.TestCase):
                 + "\n"
                 + "## Stats\n"
                 + "\n"
-                + "| day | language | who | part | time (s) | mem (KiB) | notes |\n"
-                + "| --- | --- | --- | --- | --- | --- | --- |\n"
-                + "| 01 | python | iain | three | 0.01 | 1792 | |\n"
+                + "| day | language | who | lines | part | time (s) | mem (KiB) | notes |\n"
+                + "| --- | --- | --- | --- | --- | --- | --- | --- |\n"
+                + "| 01 | python | iain | 7 | three | 0.01 | 1792 | |\n"
                 + "\n"
                 + "\n"
             )

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -366,5 +366,17 @@ class TestExpectsGPG(unittest.TestCase):
             main.make_input_file()
 
 
+class TestLineCount(unittest.TestCase):
+    """Test the lines-of-code counting function."""
+
+    def test_count_lines(self) -> None:
+        """The count_lines func gives the expected answer."""
+        with main.chdir(Path("day_99/python_iain")):
+            self.assertEqual(14, main.count_lines("python"))
+
+        with main.chdir(Path("day_99/python_zain")):
+            self.assertEqual(2, main.count_lines("python"))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -288,10 +288,10 @@ class TestMain(unittest.TestCase):
         run = ("01", "python", "iain")
         stat = ("0.01", "1792", "")
 
-        main.write_results({run: (stat, stat)})
+        main.write_results({run: (stat, stat, 3)})
         self.assertEqual(expected_readme_txt, readme.read_text())
 
-        main.write_results({run: (stat, stat)})
+        main.write_results({run: (stat, stat, 3)})
         self.assertEqual(expected_readme_txt, readme.read_text())
 
     def test_write_results_two(self) -> None:
@@ -303,10 +303,10 @@ class TestMain(unittest.TestCase):
         run = ("01", "python", "iain")
         stat = ("0.01", "1792", "")
 
-        main.write_results({run: (stat, stat)})
+        main.write_results({run: (stat, stat, 8)})
         self.assertEqual(expected_readme_txt, readme.read_text())
 
-        main.write_results({run: (stat, stat)})
+        main.write_results({run: (stat, stat, 8)})
         self.assertEqual(expected_readme_txt, readme.read_text())
 
     def test_get_answers(self) -> None:
@@ -321,14 +321,14 @@ class TestMain(unittest.TestCase):
             + "\n"
             + "## Stats\n"
             + "\n"
-            + "| day | language | who | part | time (s) | mem (KiB) | notes |\n"
-            + "| --- | --- | --- | --- | --- | --- | --- |\n"
-            + "| 01 | python | iain | one | 0.01 | 1792 | |\n"
-            + "| 01 | python | iain | two | 0.01 | 1792 | |\n"
+            + "| day | language | who | lines | part | time (s) | mem (KiB) | notes |\n"
+            + "| --- | --- | --- | --- | --- | --- | --- | --- |\n"
+            + "| 01 | python | iain | 7 | one | 0.01 | 1792 | |\n"
+            + "| 01 | python | iain | 7 | two | 0.01 | 1792 | |\n"
             + "\n"
             + "\n"
         )
-        expected = {("01", "python", "iain"): (("0.01", "1792", ""), ("0.01", "1792", ""))}
+        expected = {("01", "python", "iain"): (("0.01", "1792", ""), ("0.01", "1792", ""), 7)}
         self.assertDictEqual(expected, actual)
 
     def test_from_table_raises(self) -> None:


### PR DESCRIPTION
Downgrade to Python 3.12 so that we can use pygount to count lines of code.